### PR TITLE
Fix stack traces when node is 20+

### DIFF
--- a/integration-test/stack-traces.spec.js
+++ b/integration-test/stack-traces.spec.js
@@ -1,12 +1,7 @@
 /* eslint no-unused-expressions: 0 */
 const { isFileEdited } = require('./edited-files-cache')
 
-// TODO(bengl) These tests fail on Node.js 20+ and likely always have.
-// Skipping them for now, to be fixed in a future PR.
-const [NODE_MAJOR] = process.versions.node.split('.').map(Number)
-const describeOrSkip = NODE_MAJOR <= 18 ? describe : describe.skip
-
-describeOrSkip('Test stack traces', () => {
+describe('Test stack traces', () => {
   describe('detects line and column correctly', () => {
     it('when error is created out of the methods', () => {
       const { error } = require('./requires/errors')
@@ -14,6 +9,7 @@ describeOrSkip('Test stack traces', () => {
       expect(firstStackLine).to.contain('errors.js:10:15')
       expect(isFileEdited('errors.js')).to.be.true
     })
+
     it('when error is created out of the methods in eval', () => {
       const { evalError } = require('./requires/errors')
       const firstStackLine = evalError.stack.split('\n')[1]

--- a/js/stack-trace/index.js
+++ b/js/stack-trace/index.js
@@ -2,7 +2,7 @@ const { getSourcePathAndLineFromSourceMaps } = require('../source-map')
 
 const kSymbolPrepareStackTrace = Symbol('_ddiastPrepareStackTrace')
 
-const evalRegex = /.*\(((?:.:[/\\])?[/\\].*):(\d*):(\d*)\)/g
+const evalRegex = /.*\(((?:.:[/\\]?)?[/\\].*):(\d*):(\d*)\)/g
 
 class WrappedCallSite {
   constructor (callSite) {

--- a/js/stack-trace/index.js
+++ b/js/stack-trace/index.js
@@ -2,13 +2,33 @@ const { getSourcePathAndLineFromSourceMaps } = require('../source-map')
 
 const kSymbolPrepareStackTrace = Symbol('_ddiastPrepareStackTrace')
 
+const evalRegex = /.*\(((?:.:[/\\])?[/\\].*):(\d*):(\d*)\)/g
+
 class WrappedCallSite {
   constructor (callSite) {
+    if (callSite.isEval()) {
+      evalRegex.lastIndex = 0
+      const evalOrigin = callSite.getEvalOrigin()
+      const evalData = evalRegex.exec(evalOrigin)
+
+      if (evalData) {
+        const { path, line, column } = getSourcePathAndLineFromSourceMaps(
+          evalData[1],
+          evalData[2],
+          evalData[3]
+        )
+
+        this.evalOrigin = evalOrigin.replace(`${evalData[1]}:${evalData[2]}:${evalData[3]}`,
+          `${path}:${line}:${column}`)
+      }
+    }
+
     const { path, line, column } = getSourcePathAndLineFromSourceMaps(
       callSite.getFileName(),
       callSite.getLineNumber(),
       callSite.getColumnNumber()
     )
+
     this.source = path
     this.lineNumber = line
     this.columnNumber = column
@@ -52,7 +72,7 @@ class WrappedCallSite {
   }
 
   getEvalOrigin () {
-    return this.callSite.getEvalOrigin()
+    return this.evalOrigin || this.callSite.getEvalOrigin()
   }
 
   isToplevel () {
@@ -72,7 +92,17 @@ class WrappedCallSite {
   }
 
   toString () {
-    return this.callSite.toString()
+    let callSiteString = this.callSite.toString()
+
+    if (this.isEval()) {
+      callSiteString = callSiteString.replace(this.callSite.getEvalOrigin(), this.evalOrigin)
+    }
+
+    const newFileLineChar = `${this.source}:${this.lineNumber}:${this.columnNumber})`
+    const originalFileLineChar =
+      `${this.callSite.getFileName()}:${this.callSite.getLineNumber()}:${this.callSite.getColumnNumber()})`
+
+    return callSiteString.toString()?.replace(originalFileLineChar, newFileLineChar)
   }
 
   toLocaleString () {

--- a/js/stack-trace/index.js
+++ b/js/stack-trace/index.js
@@ -95,7 +95,7 @@ class WrappedCallSite {
     let callSiteString = this.callSite.toString()
 
     if (this.isEval()) {
-      callSiteString = callSiteString.replace(this.callSite.getEvalOrigin(), this.evalOrigin)
+      callSiteString = callSiteString.replace(this.callSite.getEvalOrigin(), this.getEvalOrigin())
     }
 
     const newFileLineChar = `${this.source}:${this.lineNumber}:${this.columnNumber})`


### PR DESCRIPTION
### What does this PR do?
Fixes the stacktraces in nodejs versions >= 20
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
The Stack Trace generation was wrong for node 20+. In newest nodejs versions prepareStackTrace is setted (https://github.com/nodejs/node/blob/v20.x/lib/internal/bootstrap/realm.js#L462) and it executes a `toString` of each CallSite. 

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
