### PR TITLE
Ensure correct spelling of Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dd-wasm-js-rewriter
 
-Nodejs native AST rewriter heavily based on [Speedy Web Compiler o SWC compiler](https://github.com/swc-project/swc) used to instrument Javascript source files.
+Node.js native AST rewriter heavily based on [Speedy Web Compiler o SWC compiler](https://github.com/swc-project/swc) used to instrument Javascript source files.
 
 ## Workflow
 

--- a/js/source-map/node_source_map.js
+++ b/js/source-map/node_source_map.js
@@ -1,6 +1,6 @@
 // This file is a modified version of:
 // https://github.com/nodejs/node/blob/5e57d24d325f0aea74394f78ebdc06857cca77b1/lib/internal/source_map/source_map.js
-// from the NodeJs codebase
+// from the Node.js codebase
 
 // This file is a modified version of:
 // https://cs.chromium.org/chromium/src/v8/tools/SourceMap.js?rcl=dd10454c1d

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@datadog/wasm-js-rewriter",
   "homepage": "https://github.com/DataDog/dd-wasm-js-rewriter/blob/main/README.md",
   "version": "4.0.1",
-  "description": "Datadog instrumentation addon for NodeJS",
+  "description": "Datadog instrumentation addon for Node.js",
   "main": "main.js",
   "types": "index.d.ts",
   "repository": {


### PR DESCRIPTION
### What does this PR do?

Fix wrong spellings of Node.js (wrong: NodeJS, Node.Js, Node.JS etc).

### Motivation

The way we spell "Node.js" is a signal about how we treat the Node.js community. By spelling the name of their language incorrectly, it could be interpreted as not caring/respecting, which obviously we do ☺️

### Additional Notes

Inspired in this [PR](https://github.com/DataDog/dd-trace-js/pull/5622)